### PR TITLE
fixup: append vendor suffix to `libuuid`

### DIFF
--- a/extract-files.py
+++ b/extract-files.py
@@ -44,6 +44,7 @@ lib_fixups: lib_fixups_user_type = {
     **lib_fixups,
     ('vendor.mediatek.hardware.videotelephony@1.0',): lib_fixup_vendor_suffix,
     ('libsink',): lib_fixup_remove,
+    'libuuid': lib_fixup_vendor_suffix,
 }
 
 blob_fixups: blob_fixups_user_type = {


### PR DESCRIPTION
error: vendor/samsung/mt6789-common/Android.bp:8220:1: module "tzts_daemon" vari ant "android_vendor_arm64_armv8-2a-dotprod": module "libuuid" is not a shared li brary
error: vendor/samsung/mt6789-common/Android.bp:8195:1: module "tzdaemon" variant
 "android_vendor_arm64_armv8-2a-dotprod": module "libuuid" is not a shared libra
ry