### PR TITLE
remove non existent `hostapd` 

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -259,7 +259,6 @@ PRODUCT_COPY_FILES += \
 # Wi-Fi
 PRODUCT_PACKAGES += \
     wpa_supplicant \
-    hostapd \
     libwifi-hal-wrapper \
     android.hardware.wifi-service
 # not sure why these hals were commented out either


### PR DESCRIPTION
build/make/core/main.mk:1117: warning:  device/samsung/gta9/lineage_gta9.mk includes non-existent modules in PRODUCT_PACKAGES Offending entries:
hostapd